### PR TITLE
Fixed beautification mistakes

### DIFF
--- a/Scripts/Content/Story/Missions/DIA_PAL_1029_Osraed.d
+++ b/Scripts/Content/Story/Missions/DIA_PAL_1029_Osraed.d
@@ -151,7 +151,7 @@ instance PAL_1029_EXIT(C_Info)
 
 func int PAL_1029_EXIT_Condition()
 {
-	return FALSE;
+	return TRUE;
 };
 
 func void PAL_1029_EXIT_Info()


### PR DESCRIPTION
Fixed the following mistakes:

- Beautification: Dialogue condition `return 1` was incorrectly replaced with `return FALSE`.